### PR TITLE
feat: Allow sending pictures up to 2560px

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AndroidUtilities.java
@@ -2500,7 +2500,7 @@ public class AndroidUtilities {
 
     public static int getPhotoSize() {
         if (photoSize == null) {
-            photoSize = 1280;
+            photoSize = 2560;
         }
         return photoSize;
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Crop/CropView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Crop/CropView.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 
 public class CropView extends FrameLayout implements CropAreaView.AreaViewListener, CropGestureDetector.CropGestureListener {
     private static final float EPSILON = 0.00001f;
-    private static final int RESULT_SIDE = 1280;
+    private static final int RESULT_SIDE = 2560;
     private static final float MAX_SCALE = 30.0f;
 
     public CropAreaView areaView;


### PR DESCRIPTION
## Tittle Here
Better quality photo

## Description
https://github.com/DrKLO/Telegram/pull/1790

For reference:
https://github.com/Nekogram/Nekogram/commit/fad3e1a9528e7b229dc1159b59efa83d57709d27

https://github.com/OwlGramDev/OwlGram/commit/976a1ce4bddb38f09711844d4afe0ba8b132afcf

This setting has worked perfectly for over 2 years, there's no point in making an extra button in the settings, it works without a problem. For those who have it enabled, it gives a huge advantage in image quality. Telegram desktop does display photo with higher resolution by default
