### PR TITLE
fix(tcp2ws): refresh check status after toggling

### DIFF
--- a/TMessagesProj/src/main/java/top/qwq2333/nullgram/activity/WsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/top/qwq2333/nullgram/activity/WsSettingsActivity.java
@@ -71,7 +71,7 @@ public class WsSettingsActivity extends BaseActivity {
         if (position == enableTLSRow) {
             WebSocketHelper.toggleWsEnableTLS();
             if (view instanceof TextCheckCell) {
-                ((TextCheckCell) view).setChecked(WebSocketHelper.wsEnableTLS);
+                ((TextCheckCell) view).setChecked(WebSocketHelper.wsEnableTLS());
             }
             WebSocketHelper.wsReloadConfig();
         } else if (position == providerRow) {
@@ -221,7 +221,7 @@ public class WsSettingsActivity extends BaseActivity {
                 case TYPE_CHECK: {
                     TextCheckCell textCell = (TextCheckCell) holder.itemView;
                     if (position == enableTLSRow) {
-                        textCell.setTextAndCheck(LocaleController.getString("WsEnableTls", R.string.WsEnableTls), WebSocketHelper.wsEnableTLS, true);
+                        textCell.setTextAndCheck(LocaleController.getString("WsEnableTls", R.string.WsEnableTls), WebSocketHelper.wsEnableTLS(), true);
                     }
                     break;
                 }

--- a/TMessagesProj/src/main/java/top/qwq2333/nullgram/helpers/WebSocketHelper.kt
+++ b/TMessagesProj/src/main/java/top/qwq2333/nullgram/helpers/WebSocketHelper.kt
@@ -69,8 +69,13 @@ object WebSocketHelper {
         return Pair(names, types)
     }
 
-    @JvmField
-    var wsEnableTLS = Config.wsEnableTLS
+    @JvmStatic
+    @get:JvmName("wsEnableTLS")
+    var wsEnableTLS: Boolean
+        get() = Config.wsEnableTLS
+        set(value) {
+            Config.wsEnableTLS = value
+        }
 
     @JvmStatic
     fun toggleWsEnableTLS() {


### PR DESCRIPTION
# Title
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

Refresh `wsEnableTLS` check status after toggling.

## Description
<!--- Describe your changes in detail here. -->

Previously, `wsEnableTLS` was marked with `@JvmField`, which caused it to only read `Config.wsEnableTLS` during initialization. All subsequent get operations would not read the value from `Config.wsEnableTLS`, resulting in the check status will not update when toggling occurrs.

## Issues Fixed or Closed by This PR

The check status will not update when toggling occurrs.

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] My code follows the code style of this project
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
